### PR TITLE
Ensures ProfileTrustAgent properly grants/revokes trust [2/2] 

### DIFF
--- a/api/cm_current.txt
+++ b/api/cm_current.txt
@@ -972,6 +972,7 @@ package cyanogenmod.providers {
     field public static final java.lang.String QS_SHOW_BRIGHTNESS_SLIDER = "qs_show_brightness_slider";
     field public static final java.lang.String RECENTS_SHOW_SEARCH_BAR = "recents_show_search_bar";
     field public static final java.lang.String REVERSE_LOOKUP_PROVIDER = "reverse_lookup_provider";
+    field public static final java.lang.String LOCKSCREEN_ROTATION = "lockscreen_rotation";
     field public static final java.lang.String SHOW_ALARM_ICON = "show_alarm_icon";
     field public static final java.lang.String STATUS_BAR_AM_PM = "status_bar_am_pm";
     field public static final java.lang.String STATUS_BAR_BATTERY_STYLE = "status_bar_battery_style";

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/AppSuggestManagerService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/AppSuggestManagerService.java
@@ -26,13 +26,12 @@ import com.android.server.SystemService;
 import cyanogenmod.app.CMContextConstants;
 import cyanogenmod.app.suggest.ApplicationSuggestion;
 import cyanogenmod.app.suggest.IAppSuggestManager;
-import cyanogenmod.platform.Manifest;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /** @hide */
-public class AppSuggestManagerService extends SystemService {
+public class AppSuggestManagerService extends CMSystemService {
     private static final String TAG = "AppSgstMgrService";
     public static final boolean DEBUG = Log.isLoggable(TAG, Log.DEBUG);
 
@@ -63,6 +62,11 @@ public class AppSuggestManagerService extends SystemService {
     }
 
     @Override
+    public String getFeatureDeclaration() {
+        return CMContextConstants.Features.APP_SUGGEST;
+    }
+
+    @Override
     public void onStart() {
         mImpl = AppSuggestProviderProxy.createAndBind(mContext, TAG, ACTION,
                 R.bool.config_enableAppSuggestOverlay,
@@ -73,13 +77,6 @@ public class AppSuggestManagerService extends SystemService {
         } else {
             Slog.i(TAG, "Bound to to suggest provider");
         }
-
-        if (mContext.getPackageManager().hasSystemFeature(
-                CMContextConstants.Features.APP_SUGGEST)) {
-            publishBinderService(CMContextConstants.CM_APP_SUGGEST_SERVICE, mService);
-        } else {
-            Log.wtf(TAG, "CM hardware service started by system server but feature xml not" +
-                    " declared. Not publishing binder service!");
-        }
+        publishBinderService(CMContextConstants.CM_APP_SUGGEST_SERVICE, mService);
     }
 }

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/CMAudioService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/CMAudioService.java
@@ -36,7 +36,7 @@ import cyanogenmod.media.CMAudioManager;
 import cyanogenmod.media.ICMAudioService;
 import cyanogenmod.platform.Manifest;
 
-public class CMAudioService extends SystemService {
+public class CMAudioService extends CMSystemService {
 
     private static final String TAG = "CMAudioService";
     private static final boolean DEBUG = Log.isLoggable(TAG, Log.DEBUG);
@@ -55,14 +55,12 @@ public class CMAudioService extends SystemService {
     }
 
     @Override
-    public void onStart() {
-        if (!mContext.getPackageManager().hasSystemFeature(
-                CMContextConstants.Features.AUDIO)) {
-            Log.wtf(TAG, "CM Audio service started by system server but feature xml not" +
-                    " declared. Not publishing binder service!");
-            return;
-        }
+    public String getFeatureDeclaration() {
+        return CMContextConstants.Features.AUDIO;
+    }
 
+    @Override
+    public void onStart() {
         if (!NativeHelper.isNativeLibraryAvailable()) {
             Log.wtf(TAG, "CM Audio service started by system server by native library is" +
                     "unavailable. Service will be unavailable.");

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/CMHardwareService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/CMHardwareService.java
@@ -54,7 +54,7 @@ import org.cyanogenmod.hardware.UniqueDeviceId;
 import org.cyanogenmod.hardware.VibratorHW;
 
 /** @hide */
-public class CMHardwareService extends SystemService implements ThermalUpdateCallback {
+public class CMHardwareService extends CMSystemService implements ThermalUpdateCallback {
 
     private static final boolean DEBUG = true;
     private static final String TAG = CMHardwareService.class.getSimpleName();
@@ -344,13 +344,12 @@ public class CMHardwareService extends SystemService implements ThermalUpdateCal
         super(context);
         mContext = context;
         mCmHwImpl = getImpl(context);
-        if (context.getPackageManager().hasSystemFeature(
-                CMContextConstants.Features.HARDWARE_ABSTRACTION)) {
-            publishBinderService(CMContextConstants.CM_HARDWARE_SERVICE, mService);
-        } else {
-            Log.wtf(TAG, "CM hardware service started by system server but feature xml not" +
-                    " declared. Not publishing binder service!");
-        }
+        publishBinderService(CMContextConstants.CM_HARDWARE_SERVICE, mService);
+    }
+
+    @Override
+    public String getFeatureDeclaration() {
+        return CMContextConstants.Features.HARDWARE_ABSTRACTION;
     }
 
     @Override

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/CMStatusBarManagerService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/CMStatusBarManagerService.java
@@ -58,7 +58,7 @@ import org.cyanogenmod.platform.internal.R;
  * Internal service which manages interactions with system ui elements
  * @hide
  */
-public class CMStatusBarManagerService extends SystemService {
+public class CMStatusBarManagerService extends CMSystemService {
     private static final String TAG = "CMStatusBarManagerService";
 
     private Context mContext;
@@ -82,13 +82,12 @@ public class CMStatusBarManagerService extends SystemService {
     }
 
     @Override
+    public String getFeatureDeclaration() {
+        return CMContextConstants.Features.STATUSBAR;
+    }
+
+    @Override
     public void onStart() {
-        if (!mContext.getPackageManager().hasSystemFeature(
-                CMContextConstants.Features.STATUSBAR)) {
-            Log.wtf(TAG, "CM statusbar service started by system server but feature xml not" +
-                    " declared. Not publishing binder service!");
-            return;
-        }
         Log.d(TAG, "registerCMStatusBar cmstatusbar: " + this);
         mCustomTileListeners = new CustomTileListeners();
         publishBinderService(CMContextConstants.CM_STATUS_BAR_SERVICE, mService);

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/CMSystemServer.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/CMSystemServer.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2016 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cyanogenmod.platform.internal;
+
+import android.content.Context;
+import android.util.Slog;
+import com.android.server.LocalServices;
+import com.android.server.SystemService;
+import com.android.server.SystemServiceManager;
+import cyanogenmod.app.CMContextConstants;
+
+import org.cyanogenmod.platform.internal.display.LiveDisplayService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base CM System Server which handles the starting and states of various CM
+ * specific system services. Since its part of the main looper provided by the system
+ * server, it will be available indefinitely (until all the things die).
+ */
+public class CMSystemServer {
+    private static final String TAG = "CMSystemServer";
+    private Context mSystemContext;
+    private CMSystemServiceHelper mSystemServiceHelper;
+
+    public CMSystemServer(Context systemContext) {
+        mSystemContext = systemContext;
+        mSystemServiceHelper = new CMSystemServiceHelper(mSystemContext);
+    }
+
+    /**
+     * Invoked via reflection by the SystemServer
+     */
+    private void run() {
+        // Start services.
+        try {
+            startServices();
+        } catch (Throwable ex) {
+            Slog.e("System", "******************************************");
+            Slog.e("System", "************ Failure starting cm system services", ex);
+            throw ex;
+        }
+    }
+
+    private void startServices() {
+        final Context context = mSystemContext;
+        final SystemServiceManager ssm = LocalServices.getService(SystemServiceManager.class);
+        String[] externalServices = context.getResources().getStringArray(
+                org.cyanogenmod.platform.internal.R.array.config_externalCMServices);
+
+        for (String service : externalServices) {
+            try {
+                Slog.i(TAG, "Attempting to start service " + service);
+                CMSystemService cmSystemService =  mSystemServiceHelper.getServiceFor(service);
+                if (context.getPackageManager().hasSystemFeature(
+                        cmSystemService.getFeatureDeclaration())) {
+                    Slog.i(TAG, "Starting service " + service);
+                    ssm.startService(cmSystemService.getClass());
+                } else {
+                    Slog.i(TAG, "Not starting service " + service +
+                            " due to feature not declared on device");
+                }
+            } catch (Throwable e) {
+                reportWtf("starting " + service , e);
+            }
+        }
+    }
+
+    private void reportWtf(String msg, Throwable e) {
+        Slog.w(TAG, "***********************************************");
+        Slog.wtf(TAG, "BOOT FAILURE " + msg, e);
+    }
+}

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/CMSystemService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/CMSystemService.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2016 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cyanogenmod.platform.internal;
+
+import android.content.Context;
+import com.android.server.SystemService;
+
+public abstract class CMSystemService extends SystemService {
+    public CMSystemService(Context context) {
+        super(context);
+    }
+
+    public abstract String getFeatureDeclaration();
+}

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/CMSystemServiceHelper.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/CMSystemServiceHelper.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2016 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cyanogenmod.platform.internal;
+
+import android.content.Context;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Helper methods for fetching a CMSystemService from a class declaration
+ */
+public class CMSystemServiceHelper {
+    private Context mContext;
+
+    public CMSystemServiceHelper(Context context) {
+        mContext = context;
+    }
+
+    public CMSystemService getServiceFor(String className) {
+        final Class<CMSystemService> serviceClass;
+        try {
+            serviceClass = (Class<CMSystemService>)Class.forName(className);
+        } catch (ClassNotFoundException ex) {
+            throw new RuntimeException("Failed to create service " + className
+                    + ": service class not found", ex);
+        }
+
+        return getServiceFromClass(serviceClass);
+    }
+
+    public <T extends CMSystemService> T getServiceFromClass(Class<T> serviceClass) {
+        final T service;
+        try {
+            Constructor<T> constructor = serviceClass.getConstructor(Context.class);
+            service = constructor.newInstance(mContext);
+        } catch (InstantiationException ex) {
+            throw new RuntimeException("Failed to create service " + serviceClass
+                    + ": service could not be instantiated", ex);
+        } catch (IllegalAccessException ex) {
+            throw new RuntimeException("Failed to create service " + serviceClass
+                    + ": service must have a public constructor with a Context argument", ex);
+        } catch (NoSuchMethodException ex) {
+            throw new RuntimeException("Failed to create service " + serviceClass
+                    + ": service must have a public constructor with a Context argument", ex);
+        } catch (InvocationTargetException ex) {
+            throw new RuntimeException("Failed to create service " + serviceClass
+                    + ": service constructor threw an exception", ex);
+        }
+        return service;
+    }
+}

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/CMTelephonyManagerService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/CMTelephonyManagerService.java
@@ -36,7 +36,7 @@ import cyanogenmod.app.ICMTelephonyManager;
  *
  * @hide
  */
-public class CMTelephonyManagerService extends SystemService {
+public class CMTelephonyManagerService extends CMSystemService {
     private static final String TAG = "CMTelephonyManagerSrv";
     private static boolean localLOGD = Log.isLoggable(TAG, Log.DEBUG);
 
@@ -182,17 +182,16 @@ public class CMTelephonyManagerService extends SystemService {
     }
 
     @Override
+    public String getFeatureDeclaration() {
+        return CMContextConstants.Features.TELEPHONY;
+    }
+
+    @Override
     public void onStart() {
         if (localLOGD) {
             Log.d(TAG, "CM telephony manager service start: " + this);
         }
-        if (mContext.getPackageManager().hasSystemFeature(
-                CMContextConstants.Features.TELEPHONY)) {
-            publishBinderService(CMContextConstants.CM_TELEPHONY_MANAGER_SERVICE, mService);
-        } else {
-            Log.wtf(TAG, "CM telephony service started by system server but feature xml not" +
-                    " declared. Not publishing binder service!");
-        }
+        publishBinderService(CMContextConstants.CM_TELEPHONY_MANAGER_SERVICE, mService);
         mTelephonyManager = (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
     }
 

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/CMWeatherManagerService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/CMWeatherManagerService.java
@@ -54,7 +54,7 @@ import cyanogenmod.weatherservice.ServiceRequestResult;
 import java.util.ArrayList;
 import java.util.List;
 
-public class CMWeatherManagerService extends SystemService{
+public class CMWeatherManagerService extends CMSystemService {
 
     private static final String TAG = CMWeatherManagerService.class.getSimpleName();
 
@@ -219,6 +219,11 @@ public class CMWeatherManagerService extends SystemService{
     public CMWeatherManagerService(Context context) {
         super(context);
         mContext = context;
+    }
+
+    @Override
+    public String getFeatureDeclaration() {
+        return CMContextConstants.Features.WEATHER_SERVICES;
     }
 
     @Override

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/IconCacheManagerService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/IconCacheManagerService.java
@@ -35,7 +35,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 /** @hide */
-public class IconCacheManagerService extends SystemService {
+public class IconCacheManagerService extends CMSystemService {
     private static final String TAG = IconCacheManagerService.class.getSimpleName();
 
     private static final long MAX_ICON_CACHE_SIZE = 33554432L; // 32MB
@@ -50,14 +50,14 @@ public class IconCacheManagerService extends SystemService {
     }
 
     @Override
+    public String getFeatureDeclaration() {
+        return CMContextConstants.Features.THEMES;
+    }
+
+    @Override
     public void onStart() {
         Log.d(TAG, "registerIconCache cmiconcache: " + this);
-        if (mContext.getPackageManager().hasSystemFeature(CMContextConstants.Features.THEMES)) {
-            publishBinderService(CMContextConstants.CM_ICON_CACHE_SERVICE, mService);
-        } else {
-            Log.wtf(TAG, "IconCache service started by system server but feature xml not" +
-                    " declared. Not publishing binder service!");
-        }
+        publishBinderService(CMContextConstants.CM_ICON_CACHE_SERVICE, mService);
     }
 
     private void purgeIconCache() {

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/LiveLockScreenServiceBroker.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/LiveLockScreenServiceBroker.java
@@ -52,7 +52,7 @@ import java.util.List;
  *
  * @hide
  */
-public class LiveLockScreenServiceBroker extends SystemService {
+public class LiveLockScreenServiceBroker extends CMSystemService {
     private static final String TAG = LiveLockScreenServiceBroker.class.getSimpleName();
     private static final boolean DEBUG = false;
 
@@ -235,16 +235,14 @@ public class LiveLockScreenServiceBroker extends SystemService {
     }
 
     @Override
+    public String getFeatureDeclaration() {
+        return CMContextConstants.Features.LIVE_LOCK_SCREEN;
+    }
+
+    @Override
     public void onStart() {
         if (DEBUG) Slog.d(TAG, "service started");
-        if (mContext.getPackageManager().hasSystemFeature(
-                CMContextConstants.Features.LIVE_LOCK_SCREEN)) {
-            publishBinderService(CMContextConstants.CM_LIVE_LOCK_SCREEN_SERVICE,
-                    new BinderService());
-        } else {
-            Slog.wtf(TAG, "CM live lock screen service started by system server but feature xml " +
-                    "not declared. Not publishing binder service!");
-        }
+        publishBinderService(CMContextConstants.CM_LIVE_LOCK_SCREEN_SERVICE, new BinderService());
     }
 
     @Override

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/PartnerInterfaceService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/PartnerInterfaceService.java
@@ -48,7 +48,7 @@ import java.security.interfaces.RSAPublicKey;
 
 /** @hide */
 
-public class PartnerInterfaceService extends SystemService {
+public class PartnerInterfaceService extends CMSystemService {
 
     private static final String TAG = "CMSettingsService";
 
@@ -60,13 +60,12 @@ public class PartnerInterfaceService extends SystemService {
     public PartnerInterfaceService(Context context) {
         super(context);
         mContext = context;
-        if (mContext.getPackageManager().hasSystemFeature(
-                CMContextConstants.Features.PARTNER)) {
-            publishBinderService(CMContextConstants.CM_PARTNER_INTERFACE, mService);
-        } else {
-            Log.wtf(TAG, "CM partner service started by system server but feature xml not" +
-                    " declared. Not publishing binder service!");
-        }
+        publishBinderService(CMContextConstants.CM_PARTNER_INTERFACE, mService);
+    }
+
+    @Override
+    public String getFeatureDeclaration() {
+        return CMContextConstants.Features.PARTNER;
     }
 
     @Override

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/PerformanceManagerService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/PerformanceManagerService.java
@@ -41,7 +41,7 @@ import cyanogenmod.power.PerformanceManagerInternal;
 import cyanogenmod.providers.CMSettings;
 
 /** @hide */
-public class PerformanceManagerService extends SystemService {
+public class PerformanceManagerService extends CMSystemService {
 
     private static final String TAG = "PerformanceManager";
 
@@ -105,14 +105,13 @@ public class PerformanceManagerService extends SystemService {
     }
 
     @Override
+    public String getFeatureDeclaration() {
+        return CMContextConstants.Features.PERFORMANCE;
+    }
+
+    @Override
     public void onStart() {
-        if (mContext.getPackageManager().hasSystemFeature(
-                CMContextConstants.Features.PERFORMANCE)) {
-            publishBinderService(CMContextConstants.CM_PERFORMANCE_SERVICE, mBinder);
-        } else {
-            Log.wtf(TAG, "CM performance service started by system server but feature xml not" +
-                    " declared. Not publishing binder service!");
-        }
+        publishBinderService(CMContextConstants.CM_PERFORMANCE_SERVICE, mBinder);
         publishLocalService(PerformanceManagerInternal.class, new LocalService());
     }
 

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/ProfileManagerService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/ProfileManagerService.java
@@ -62,7 +62,7 @@ import java.util.Map;
 import java.util.UUID;
 
 /** @hide */
-public class ProfileManagerService extends SystemService {
+public class ProfileManagerService extends CMSystemService {
 
     private static final String TAG = "CMProfileService";
     // Enable the below for detailed logging of this class
@@ -176,6 +176,11 @@ public class ProfileManagerService extends SystemService {
             Log.wtf(TAG, "CM profile service started by system server but feature xml not" +
                     " declared. Not publishing binder service!");
         }
+    }
+
+    @Override
+    public String getFeatureDeclaration() {
+        return CMContextConstants.Features.PROFILES;
     }
 
     @Override

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/ThemeManagerService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/ThemeManagerService.java
@@ -623,7 +623,7 @@ public class ThemeManagerService extends CMSystemService {
     private boolean updateAudible(String dirPath, String assetPath, int type, String pkgName) {
         //Clear the dir
         ThemeUtils.clearAudibles(mContext, dirPath);
-        if (pkgName.equals(SYSTEM_DEFAULT)) {
+        if (TextUtils.isEmpty(pkgName) || pkgName.equals(SYSTEM_DEFAULT)) {
             if (!ThemeUtils.setDefaultAudible(mContext, type)) {
                 Log.e(TAG, "There was an error installing the default audio file");
                 return false;

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/ThemeManagerService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/ThemeManagerService.java
@@ -87,7 +87,7 @@ import static cyanogenmod.platform.Manifest.permission.ACCESS_THEME_MANAGER;
 import static org.cyanogenmod.internal.util.ThemeUtils.SYSTEM_THEME_PATH;
 import static org.cyanogenmod.internal.util.ThemeUtils.THEME_BOOTANIMATION_PATH;
 
-public class ThemeManagerService extends SystemService {
+public class ThemeManagerService extends CMSystemService {
 
     private static final String TAG = ThemeManagerService.class.getName();
 
@@ -235,13 +235,13 @@ public class ThemeManagerService extends SystemService {
     }
 
     @Override
+    public String getFeatureDeclaration() {
+        return CMContextConstants.Features.THEMES;
+    }
+
+    @Override
     public void onStart() {
-        if (mContext.getPackageManager().hasSystemFeature(CMContextConstants.Features.THEMES)) {
-            publishBinderService(CMContextConstants.CM_THEME_SERVICE, mService);
-        } else {
-            Log.wtf(TAG, "Theme service started by system server but feature xml not" +
-                    " declared. Not publishing binder service!");
-        }
+        publishBinderService(CMContextConstants.CM_THEME_SERVICE, mService);
         // listen for wallpaper changes
         IntentFilter filter = new IntentFilter(Intent.ACTION_WALLPAPER_CHANGED);
         mContext.registerReceiver(mWallpaperChangeReceiver, filter);

--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/display/LiveDisplayService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/display/LiveDisplayService.java
@@ -54,6 +54,7 @@ import com.android.server.twilight.TwilightState;
 
 import org.cyanogenmod.internal.util.QSConstants;
 import org.cyanogenmod.internal.util.QSUtils;
+import org.cyanogenmod.platform.internal.CMSystemService;
 import org.cyanogenmod.platform.internal.R;
 
 import java.io.FileDescriptor;
@@ -79,7 +80,7 @@ import cyanogenmod.providers.CMSettings;
  * and calibration. It interacts with CMHardwareService to relay
  * changes down to the lower layers.
  */
-public class LiveDisplayService extends SystemService {
+public class LiveDisplayService extends CMSystemService {
 
     private static final String TAG = "LiveDisplay";
 
@@ -147,14 +148,13 @@ public class LiveDisplayService extends SystemService {
     }
 
     @Override
+    public String getFeatureDeclaration() {
+        return CMContextConstants.Features.LIVEDISPLAY;
+    }
+
+    @Override
     public void onStart() {
-        if (mContext.getPackageManager().hasSystemFeature(
-                CMContextConstants.Features.LIVEDISPLAY)) {
-            publishBinderService(CMContextConstants.CM_LIVEDISPLAY_SERVICE, mBinder);
-        } else {
-            Log.wtf(TAG, "CM LiveDisplay service started by system server but feature xml not" +
-                    " declared. Not publishing binder service!");
-        }
+        publishBinderService(CMContextConstants.CM_LIVEDISPLAY_SERVICE, mBinder);
     }
 
     @Override

--- a/cm/res/res/values-da/strings.xml
+++ b/cm/res/res/values-da/strings.xml
@@ -98,6 +98,16 @@
   <string name="live_display_outdoor">Udendørs (stærk sol)</string>
   <string name="live_display_outdoor_summary">Brug kun udendørsindstillinger</string>
   <string name="live_display_hint">LiveDisplay kan hjælpe med at reducere overanstrengelse af øjnene og hjælpe dig med at sove om natten. Klik her for at prøve det!</string>
+  <string name="accessibility_quick_settings_live_display_off">LiveDisplay fra.</string>
+  <string name="accessibility_quick_settings_live_display_auto">LiveDisplay: automatisk tilstand.</string>
+  <string name="accessibility_quick_settings_live_display_day">LiveDisplay: dag tilstand.</string>
+  <string name="accessibility_quick_settings_live_display_night">LiveDisplay: nat tilstand.</string>
+  <string name="accessibility_quick_settings_live_display_outdoor">LiveDisplay: udendørstilstand.</string>
+  <string name="accessibility_quick_settings_live_display_changed_off">LiveDisplay er slået fra.</string>
+  <string name="accessibility_quick_settings_live_display_changed_auto">LiveDisplay ændret til automatisk tilstand.</string>
+  <string name="accessibility_quick_settings_live_display_changed_day">LiveDisplay ændret til dag tilstand.</string>
+  <string name="accessibility_quick_settings_live_display_changed_night">LiveDisplay ændret til nat tilstand.</string>
+  <string name="accessibility_quick_settings_live_display_changed_outdoor">LiveDisplay ændret til udendørstilstand.</string>
   <!-- Third party keyguard permission label -->
   <string name="permlab_thirdPartyKeyguard">tredjeparts skærmlås</string>
   <!-- Third party keyguard permission description -->
@@ -162,6 +172,12 @@
   <!-- DataUsageProvider read permission description -->
   <string name="permdesc_dataUsageRead">Tillader en app at læse indholdet af databasen for dataforbrug.</string>
   <!-- LiveDisplay manager permission -->
+  <string name="permlab_manageLiveDisplay">administrer indstillinger for LiveDisplay</string>
+  <string name="permdesc_manageLiveDisplay">Tillader en app at konfigurere avancerede skærmindstillinger.</string>
   <!-- CMAudioService - observe session changes permission -->
+  <string name="permlab_observe_audio_sessions">observér ændringer for lydsession</string>
+  <string name="permdesc_observe_audio_sessions">Tillader en app at observere når lyd streams bliver oprettet eller ødelagt.</string>
   <!-- QuickSettings: Themes tile -->
+  <string name="qs_themes_label">Temaer</string>
+  <string name="qs_themes_content_description">Tilpas dit tema</string>
 </resources>

--- a/cm/res/res/values-es-rUS/strings.xml
+++ b/cm/res/res/values-es-rUS/strings.xml
@@ -178,4 +178,6 @@
   <string name="permlab_observe_audio_sessions">observa los cambios en la sesión de sonido</string>
   <string name="permdesc_observe_audio_sessions">Permite que una aplicación observe los flujos de sonido que se crean y destruyen.</string>
   <!-- QuickSettings: Themes tile -->
+  <string name="qs_themes_label">Temas</string>
+  <string name="qs_themes_content_description">Personaliza tu tema</string>
 </resources>

--- a/cm/res/res/values-es/strings.xml
+++ b/cm/res/res/values-es/strings.xml
@@ -178,4 +178,6 @@
   <string name="permlab_observe_audio_sessions">observa los cambios en la sesión de sonido</string>
   <string name="permdesc_observe_audio_sessions">Permite que una aplicación observe los flujos de sonido que se crean y destruyen.</string>
   <!-- QuickSettings: Themes tile -->
+  <string name="qs_themes_label">Temas</string>
+  <string name="qs_themes_content_description">Personalizar tu tema</string>
 </resources>

--- a/cm/res/res/values-hu/strings.xml
+++ b/cm/res/res/values-hu/strings.xml
@@ -98,6 +98,16 @@
   <string name="live_display_outdoor">Kültéri (erős napfény)</string>
   <string name="live_display_outdoor_summary">Csak a kültéri beállítások használata</string>
   <string name="live_display_hint">A LiveDisplay segíthet a szemek terhelésének csökkentésében és a jobb éjszakai alvásban. Kattintson ide, hogy kipróbálja!</string>
+  <string name="accessibility_quick_settings_live_display_off">LiveDisplay ki.</string>
+  <string name="accessibility_quick_settings_live_display_auto">LiveDisplay: automatikus mód.</string>
+  <string name="accessibility_quick_settings_live_display_day">LiveDisplay: nappali mód.</string>
+  <string name="accessibility_quick_settings_live_display_night">LiveDisplay: éjszakai mód.</string>
+  <string name="accessibility_quick_settings_live_display_outdoor">LiveDisplay: szabadtéri mód.</string>
+  <string name="accessibility_quick_settings_live_display_changed_off">LiveDisplay kikapcsolva.</string>
+  <string name="accessibility_quick_settings_live_display_changed_auto">LiveDisplay automatikus módra változtatva.</string>
+  <string name="accessibility_quick_settings_live_display_changed_day">LiveDisplay nappali módra változtatva.</string>
+  <string name="accessibility_quick_settings_live_display_changed_night">LiveDisplay éjszakai módra változtatva.</string>
+  <string name="accessibility_quick_settings_live_display_changed_outdoor">LiveDisplay szabadtéri módra változtatva.</string>
   <!-- Third party keyguard permission label -->
   <string name="permlab_thirdPartyKeyguard">harmadik fél zárképernyő</string>
   <!-- Third party keyguard permission description -->
@@ -134,17 +144,41 @@
   <!-- Performance manager permission description -->
   <string name="permdesc_perfAccessDesc">Lehetővé teszi az alkalmazás számára, hogy hozzáférjen a teljesítmény szolgáltatáshoz. Általános alkalmazásoknak soha nem kell ilyen engedély.</string>
   <!-- Access live lock screen manager service permission label -->
+  <string name="permlab_accessLiveLockScreenService">hozzáférés élő zárképernyő-kezelő szolgáltatáshoz</string>
   <!-- Access live lock screen manager service permission description -->
+  <string name="permdesc_accessLiveLockScreenService">Lehetővé teszi az alkalmazás számára az élő zárképernyő-kezelő szolgáltatás elérését.</string>
   <!-- Privileged access live lock screen manager service permission label -->
+  <string name="permlab_accessLiveLockScreenServicePrivate">hozzáférés élő zárképernyő-kezelő szolgáltatáshoz</string>
   <!-- Privileged access live lock screen manager service permission description -->
+  <string name="permdesc_accessLiveLockScreenServicePrivate">Lehetővé teszi a rendszeralkalmazások számára az élő zárképernyő-kezelő szolgáltatás elérését.</string>
   <!-- Live lock screen manager service provider permission label -->
+  <string name="permlab_accessLiveLockScreenServiceProvider">élő zárképernyő-kezelő szolgáltatás biztosítása</string>
   <!-- Live lock screen manager service provider permission description -->
+  <string name="permdesc_accessLiveLockScreenServiceProvider">Lehetővé teszi a szolgáltatás számára az élő zárképernyő-kezelő szolgáltatás biztosítását.</string>
   <!-- Weather Service strings -->
+  <string name="permlab_weather_read">időjárás olvasása</string>
+  <string name="permdesc_weather_read">Lehetővé teszi az alkalmazás számára az időjárás szolgáltatói tartalom olvasását.</string>
+  <string name="permlab_weather_write">időjárás szolgáltató frissítése</string>
+  <string name="permdesc_weather_write">Lehetővé teszi az alkalmazás számár, hogy frissítse az időjárás szolgáltató tartalmát.</string>
+  <string name="permlab_weather_bind">időjárás szolgáltatóként kötés</string>
+  <string name="permdesc_weather_bind">Lehetővé teszi az alkalmazás számára, hogy mint időjárás szolgáltató kerüljön azonosításra.</string>
+  <string name="permlab_weather_access_mgr">hozzáférés időjárás szolgáltatáshoz</string>
+  <string name="permdesc_weather_access_mgr">Lehetővé teszi az alkalmazás számára a rendszer időjárás szolgáltatásának elérését. Általános alkalmazásoknak soha nem kell ilyen engedély.</string>
   <!-- DataUsageProvider write permission title -->
+  <string name="permlab_dataUsageWrite">adathasználati adatbázis módosítása</string>
   <!-- DataUsageProvider write permission description -->
+  <string name="permdesc_dataUsageWrite">Lehetővé teszi az alkalmazás számára az adathasználati adatbázis tartalmának frissítését.</string>
   <!-- DataUsageProvider read permission title -->
+  <string name="permlab_dataUsageRead">adathasználati adatbázis olvasása</string>
   <!-- DataUsageProvider read permission description -->
+  <string name="permdesc_dataUsageRead">Lehetővé teszi az alkalmazás számára az adathasználati adatbázis tartalmának olvasását.</string>
   <!-- LiveDisplay manager permission -->
+  <string name="permlab_manageLiveDisplay">LiveDisplay beállítások kezelése</string>
+  <string name="permdesc_manageLiveDisplay">Lehetővé teszi az alkalmazás számára a speciális megjelenítési beállítások konfigurálását.</string>
   <!-- CMAudioService - observe session changes permission -->
+  <string name="permlab_observe_audio_sessions">audió munkamenet változásainak megfigyelése</string>
+  <string name="permdesc_observe_audio_sessions">Lehetővé teszi az alkalmazás számára, hogy megfigyelje ahogy az audió folyamok létrejönnek és elpusztulnak.</string>
   <!-- QuickSettings: Themes tile -->
+  <string name="qs_themes_label">Témák</string>
+  <string name="qs_themes_content_description">Téma testreszabása</string>
 </resources>

--- a/cm/res/res/values-ja/strings.xml
+++ b/cm/res/res/values-ja/strings.xml
@@ -21,7 +21,7 @@
   <string name="permlab_publishCustomTile">クイック設定パネルでのカスタムタイルの作成</string>
   <string name="permdesc_publishCustomTile">クイック設定タイルの作成をアプリに許可します</string>
   <string name="permlab_modifyNetworkSettings">システムのネットワークの設定の変更</string>
-  <string name="permdesc_modifyNetworkSettings">機内モードとモバイルデータ通信の設定を変更することをアプリに許可します。</string>
+  <string name="permdesc_modifyNetworkSettings">機内モードとモバイルデータネットワークの設定を変更することをアプリに許可します。</string>
   <string name="permlab_modifySoundSettings">システムの音の設定</string>
   <string name="permdesc_modifySoundSettings">サイレントモードの音の設定を変更することをアプリに許可します。</string>
   <string name="permlab_bindCustomTileListenerService">カスタムタイルリスナーサービスのバインド</string>

--- a/cm/res/res/values-nl/strings.xml
+++ b/cm/res/res/values-nl/strings.xml
@@ -139,7 +139,7 @@
   <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
   <string name="permdesc_writeThemesDesc">Hiermee kan de app nieuwe thema\'s invoegen en wijzigen welk thema u hebt toegepast.</string>
   <!-- Performance manager permission title -->
-  <string name="permlab_perfAccess">toegang tot prestatiebeheer</string>
+  <string name="permlab_perfAccess">Toegang tot prestatiebeheer</string>
   <!-- Performance manager permission description -->
   <string name="permdesc_perfAccessDesc">Hiermee kan de app toegang krijgen tot de prestatieservice. Nooit vereist voor normale apps.</string>
   <!-- Access live lock screen manager service permission label -->

--- a/cm/res/res/values-pl/strings.xml
+++ b/cm/res/res/values-pl/strings.xml
@@ -175,6 +175,8 @@
   <string name="permlab_manageLiveDisplay">zarządzanie ustawieniami LiveDisplay</string>
   <string name="permdesc_manageLiveDisplay">Pozwala aplikacji na konfigurację zaawansowanych ustawień wyświetlacza.</string>
   <!-- CMAudioService - observe session changes permission -->
+  <string name="permlab_observe_audio_sessions">obserwuj zmiany sesji audio</string>
+  <string name="permdesc_observe_audio_sessions">Zezwalaj aplikacji na obserwowanie utworzenia lub zamknięcia strumienia dźwięku.</string>
   <!-- QuickSettings: Themes tile -->
   <string name="qs_themes_label">Motywy</string>
   <string name="qs_themes_content_description">Dostosuj swój motyw</string>

--- a/cm/res/res/values/config.xml
+++ b/cm/res/res/values/config.xml
@@ -89,7 +89,7 @@
     <!-- Default wi-fi direct name -->
     <string name="config_wifiDirectName" translatable="false"></string>
 
-    <!-- Defines external services to be started by the SystemServer at boot. The service itself
+    <!-- Defines external services to be started by the CMSystemServer at boot. The service itself
          should publish as a binder services in its onStart -->
     <string-array name="config_externalCMServices">
         <item>org.cyanogenmod.platform.internal.CMStatusBarManagerService</item>
@@ -106,4 +106,7 @@
         <item>org.cyanogenmod.platform.internal.display.LiveDisplayService</item>
         <item>org.cyanogenmod.platform.internal.CMAudioService</item>
     </string-array>
+
+    <!-- The CMSystemServer class that is invoked from Android's SystemServer -->
+    <string name="config_externalSystemServer" translatable="false">org.cyanogenmod.platform.internal.CMSystemServer</string>
 </resources>

--- a/cm/res/res/values/symbols.xml
+++ b/cm/res/res/values/symbols.xml
@@ -113,4 +113,7 @@
 
     <!-- External CM specific core services -->
     <java-symbol type="array" name="config_externalCMServices" />
+
+    <!-- CM system server -->
+    <java-symbol type="string" name="config_externalSystemServer" />
 </resources>

--- a/host/migration/src/CMSettings.java
+++ b/host/migration/src/CMSettings.java
@@ -477,6 +477,12 @@ public final class CMSettings {
                 "lockscreen_scramble_pin_layout";
 
         /**
+         * Whether keyguard will rotate to landscape mode
+         * @hide
+         */
+        public static final String LOCKSCREEN_ROTATION = "lockscreen_rotation";
+
+        /**
          * @hide
          */
         public static final String SHOW_ALARM_ICON = "show_alarm_icon";
@@ -685,6 +691,7 @@ public final class CMSettings {
                 CMSettings.System.T9_SEARCH_INPUT_LOCALE,
                 CMSettings.System.BLUETOOTH_ACCEPT_ALL_FILES,
                 CMSettings.System.LOCKSCREEN_PIN_SCRAMBLE_LAYOUT,
+                CMSettings.System.LOCKSCREEN_ROTATION,
                 CMSettings.System.SHOW_ALARM_ICON,
                 CMSettings.System.STATUS_BAR_IME_SWITCHER,
                 CMSettings.System.QS_SHOW_BRIGHTNESS_SLIDER,

--- a/sdk/src/java/cyanogenmod/app/CMStatusBarManager.java
+++ b/sdk/src/java/cyanogenmod/app/CMStatusBarManager.java
@@ -68,7 +68,7 @@ public class CMStatusBarManager {
 
         if (context.getPackageManager().hasSystemFeature(
                 cyanogenmod.app.CMContextConstants.Features.STATUSBAR) && sService == null) {
-            throw new RuntimeException("Unable to get CMStatusBarService. The service either" +
+            Log.wtf(TAG, "Unable to get CMStatusBarService. The service either" +
                     " crashed, was not started, or the interface has been called to early in" +
                     " SystemServer init");
         }

--- a/sdk/src/java/cyanogenmod/app/CMTelephonyManager.java
+++ b/sdk/src/java/cyanogenmod/app/CMTelephonyManager.java
@@ -60,7 +60,7 @@ public class CMTelephonyManager {
 
         if (context.getPackageManager().hasSystemFeature(CMContextConstants.Features.TELEPHONY)
                 && sService == null) {
-            throw new RuntimeException("Unable to get CMTelephonyManagerService. " +
+            Log.wtf(TAG, "Unable to get CMTelephonyManagerService. " +
                     "The service either crashed, was not started, or the interface has been " +
                     "called to early in SystemServer init");
         }

--- a/sdk/src/java/cyanogenmod/app/LiveLockScreenManager.java
+++ b/sdk/src/java/cyanogenmod/app/LiveLockScreenManager.java
@@ -49,7 +49,7 @@ public class LiveLockScreenManager {
         sService = getService();
         if (context.getPackageManager().hasSystemFeature(
                 CMContextConstants.Features.LIVE_LOCK_SCREEN) && sService == null) {
-            throw new RuntimeException("Unable to get LiveLockScreenManagerService. " +
+            Log.wtf(TAG, "Unable to get LiveLockScreenManagerService. " +
                     "The service either crashed, was not started, or the interface has " +
                     "been called to early in SystemServer init");
         }

--- a/sdk/src/java/cyanogenmod/app/ProfileManager.java
+++ b/sdk/src/java/cyanogenmod/app/ProfileManager.java
@@ -84,6 +84,29 @@ public class ProfileManager {
     public static final String INTENT_ACTION_PROFILE_UPDATED =
             "cyanogenmod.platform.intent.action.PROFILE_UPDATED";
 
+
+    /**
+     * @hide
+     */
+    public static final String INTENT_ACTION_PROFILE_TRIGGER_STATE_CHANGED =
+            "cyanogenmod.platform.intent.action.INTENT_ACTION_PROFILE_TRIGGER_STATE_CHANGED";
+
+    /**
+     * @hide
+     */
+    public static final String EXTRA_TRIGGER_ID = "trigger_id";
+
+    /**
+     * @hide
+     */
+    public static final String EXTRA_TRIGGER_TYPE = "trigger_type";
+
+
+    /**
+     * @hide
+     */
+    public static final String EXTRA_TRIGGER_STATE = "trigger_state";
+
     /**
      * Extra for {@link #INTENT_ACTION_PROFILE_SELECTED} and {@link #INTENT_ACTION_PROFILE_UPDATED}:
      * The name of the newly activated or updated profile

--- a/sdk/src/java/cyanogenmod/app/ProfileManager.java
+++ b/sdk/src/java/cyanogenmod/app/ProfileManager.java
@@ -224,7 +224,7 @@ public class ProfileManager {
 
         if (context.getPackageManager().hasSystemFeature(
                 cyanogenmod.app.CMContextConstants.Features.PROFILES) && sService == null) {
-            throw new RuntimeException("Unable to get ProfileManagerService. The service either" +
+            Log.wtf(TAG, "Unable to get ProfileManagerService. The service either" +
                     " crashed, was not started, or the interface has been called to early in" +
                     " SystemServer init");
         }

--- a/sdk/src/java/cyanogenmod/hardware/CMHardwareManager.java
+++ b/sdk/src/java/cyanogenmod/hardware/CMHardwareManager.java
@@ -157,7 +157,7 @@ public final class CMHardwareManager {
 
         if (context.getPackageManager().hasSystemFeature(
                 CMContextConstants.Features.HARDWARE_ABSTRACTION) && !checkService()) {
-            throw new RuntimeException("Unable to get CMHardwareService. The service either" +
+            Log.wtf(TAG, "Unable to get CMHardwareService. The service either" +
                     " crashed, was not started, or the interface has been called to early in" +
                     " SystemServer init");
         }

--- a/sdk/src/java/cyanogenmod/hardware/LiveDisplayManager.java
+++ b/sdk/src/java/cyanogenmod/hardware/LiveDisplayManager.java
@@ -129,7 +129,7 @@ public class LiveDisplayManager {
 
         if (!context.getPackageManager().hasSystemFeature(
                 CMContextConstants.Features.LIVEDISPLAY) || !checkService()) {
-            throw new RuntimeException("Unable to get LiveDisplayService. The service either" +
+            Log.wtf(TAG, "Unable to get LiveDisplayService. The service either" +
                     " crashed, was not started, or the interface has been called to early in" +
                     " SystemServer init");
         }

--- a/sdk/src/java/cyanogenmod/media/CMAudioManager.java
+++ b/sdk/src/java/cyanogenmod/media/CMAudioManager.java
@@ -95,7 +95,7 @@ public final class CMAudioManager {
 
         if (!context.getPackageManager().hasSystemFeature(
                 CMContextConstants.Features.AUDIO) || !checkService()) {
-            throw new RuntimeException("Unable to get CMAudioService. The service either" +
+            Log.wtf(TAG, "Unable to get CMAudioService. The service either" +
                     " crashed, was not started, or the interface has been called to early in" +
                     " SystemServer init");
         }

--- a/sdk/src/java/cyanogenmod/power/PerformanceManager.java
+++ b/sdk/src/java/cyanogenmod/power/PerformanceManager.java
@@ -91,7 +91,7 @@ public class PerformanceManager {
         sService = getService();
         if (context.getPackageManager().hasSystemFeature(
                 CMContextConstants.Features.PERFORMANCE) && sService == null) {
-            throw new RuntimeException("Unable to get PerformanceManagerService. The service" +
+            Log.wtf(TAG, "Unable to get PerformanceManagerService. The service" +
                     " either crashed, was not started, or the interface has been called to early" +
                     " in SystemServer init");
         }

--- a/sdk/src/java/cyanogenmod/providers/CMSettings.java
+++ b/sdk/src/java/cyanogenmod/providers/CMSettings.java
@@ -1471,6 +1471,16 @@ public final class CMSettings {
                 sBooleanValidator;
 
         /**
+         * Whether keyguard will rotate to landscape mode
+         * 0 = false, 1 = true
+         */
+        public static final String LOCKSCREEN_ROTATION = "lockscreen_rotation";
+
+        /** @hide */
+        public static final Validator LOCKSCREEN_ROTATION_VALIDATOR =
+                sBooleanValidator;
+
+        /**
          * Whether to show the alarm clock icon in the status bar.
          * 0 = 0ff, 1 = on
          */
@@ -2032,6 +2042,7 @@ public final class CMSettings {
             VALIDATORS.put(BLUETOOTH_ACCEPT_ALL_FILES, BLUETOOTH_ACCEPT_ALL_FILES_VALIDATOR);
             VALIDATORS.put(LOCKSCREEN_PIN_SCRAMBLE_LAYOUT,
                     LOCKSCREEN_PIN_SCRAMBLE_LAYOUT_VALIDATOR);
+            VALIDATORS.put(LOCKSCREEN_ROTATION, LOCKSCREEN_ROTATION_VALIDATOR);
             VALIDATORS.put(SHOW_ALARM_ICON, SHOW_ALARM_ICON_VALIDATOR);
             VALIDATORS.put(STATUS_BAR_IME_SWITCHER, STATUS_BAR_IME_SWITCHER_VALIDATOR);
             VALIDATORS.put(STATUS_BAR_QUICK_QS_PULLDOWN,

--- a/sdk/src/java/cyanogenmod/themes/ThemeManager.java
+++ b/sdk/src/java/cyanogenmod/themes/ThemeManager.java
@@ -52,7 +52,7 @@ public class ThemeManager {
         sService = getService();
         if (context.getPackageManager().hasSystemFeature(
                 CMContextConstants.Features.THEMES) && sService == null) {
-            throw new RuntimeException("Unable to get ThemeManagerService. The service either" +
+            Log.wtf(TAG, "Unable to get ThemeManagerService. The service either" +
                     " crashed, was not started, or the interface has been called to early in" +
                     " SystemServer init");
         }

--- a/sdk/src/java/cyanogenmod/weather/CMWeatherManager.java
+++ b/sdk/src/java/cyanogenmod/weather/CMWeatherManager.java
@@ -25,6 +25,7 @@ import android.os.IBinder;
 import android.os.RemoteException;
 import android.os.ServiceManager;
 import android.util.ArraySet;
+import android.util.Log;
 import cyanogenmod.app.CMContextConstants;
 import cyanogenmod.providers.CMSettings;
 import cyanogenmod.providers.WeatherContract;
@@ -90,7 +91,7 @@ public class CMWeatherManager {
 
         if (context.getPackageManager().hasSystemFeature(
                 CMContextConstants.Features.WEATHER_SERVICES) && (sWeatherManagerService == null)) {
-            throw new RuntimeException("Unable to bind the CMWeatherManagerService");
+            Log.wtf(TAG, "Unable to bind the CMWeatherManagerService");
         }
         mHandler = new Handler(appContext.getMainLooper());
     }

--- a/system-api/cm_system-current.txt
+++ b/system-api/cm_system-current.txt
@@ -972,6 +972,7 @@ package cyanogenmod.providers {
     field public static final java.lang.String QS_SHOW_BRIGHTNESS_SLIDER = "qs_show_brightness_slider";
     field public static final java.lang.String RECENTS_SHOW_SEARCH_BAR = "recents_show_search_bar";
     field public static final java.lang.String REVERSE_LOOKUP_PROVIDER = "reverse_lookup_provider";
+    field public static final java.lang.String LOCKSCREEN_ROTATION = "lockscreen_rotation";
     field public static final java.lang.String SHOW_ALARM_ICON = "show_alarm_icon";
     field public static final java.lang.String STATUS_BAR_AM_PM = "status_bar_am_pm";
     field public static final java.lang.String STATUS_BAR_BATTERY_STYLE = "status_bar_battery_style";


### PR DESCRIPTION
	Ensures ProfileTrustAgent properly grants/revokes trust [2/2]  …
Notifies the ProfileTrustAgent when a WiFi/BT event was triggered even
if no new profile was selected so the trust agent can grant/revoke trust

Filters out the multiple network state change notifications to make sure
we notify the trust agent only when the event that the profile
is tracking actually happened

Change-Id: I047861a8b145762fff24568e341373a89ee01de9
TICKET: CYNGNOS-2719