### PR TITLE
cmhw: Add support for display mode remapping

### DIFF
--- a/cm/res/res/values/config.xml
+++ b/cm/res/res/values/config.xml
@@ -70,6 +70,17 @@
     <bool name="config_defaultColorEnhancement">true</bool>
     <bool name="config_defaultCABC">true</bool>
 
+    <!-- Display mode remapping table.
+         If the mode names returned by the backend do not match
+         the predefined and translated strings in the Settings
+         app, they can be remapped here. The format is
+         "oldname:newname", one per entry. -->
+    <string-array name="config_displayModeMappings" translatable="false">
+    </string-array>
+
+    <!-- Should we filter any display modes which are unampped? -->
+    <bool name="config_filterDisplayModes">false</bool>
+
     <!-- Is the notification LED brightness adjustable ?
          Used to decide if the user can set LED brightness -->
     <bool name="config_adjustableNotificationLedBrightness">false</bool>

--- a/cm/res/res/values/symbols.xml
+++ b/cm/res/res/values/symbols.xml
@@ -81,6 +81,9 @@
     <java-symbol type="bool" name="config_defaultColorEnhancement" />
     <java-symbol type="bool" name="config_defaultCABC" />
 
+    <java-symbol type="bool" name="config_filterDisplayModes" />
+    <java-symbol type="array" name="config_displayModeMappings" />
+
     <!-- Notification and battery light -->
     <java-symbol type="bool" name="config_adjustableNotificationLedBrightness" />
     <java-symbol type="bool" name="config_multipleNotificationLeds" />


### PR DESCRIPTION
 * Simple mechanism for mapping vendor names to the
   various modes used in CM (with translations).

Change-Id: I791e6302e48f1b886dfc3228a96176d7318679d5