### PR TITLE
CMSDK : Fix generateAlertColorFromDrawable for non BitmapDrawable

### DIFF
--- a/sdk/src/java/cyanogenmod/util/ColorUtils.java
+++ b/sdk/src/java/cyanogenmod/util/ColorUtils.java
@@ -16,6 +16,7 @@
 package cyanogenmod.util;
 
 import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
@@ -270,9 +271,13 @@ public class ColorUtils {
         if (drawable instanceof BitmapDrawable) {
             bitmap = ((BitmapDrawable) drawable).getBitmap();
         } else {
-            bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(),
-                                         drawable.getIntrinsicHeight(),
+            int width = drawable.getIntrinsicWidth();
+            int height = drawable.getIntrinsicHeight();
+            bitmap = Bitmap.createBitmap(Math.max(1, width),
+                                         Math.max(1, height),
                                          Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(bitmap);
+            drawable.draw(canvas);
         }
 
         if (bitmap != null) {


### PR DESCRIPTION
In the case that the bitmap being passed in was not a bitmap drawable,
we were not retaining any of the attributes from the original drawable.
This patch ensures we ask that drawable to draw on the canvas/bitmap so we
can use that information. Also add tests around it.

Change-Id: I3eefba6e6624fe0bed4965ddf9029320c40f7420