### PR TITLE
Don't unboundedly enqueue transition messages.

### DIFF
--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/display/AmbientLuxObserver.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/display/AmbientLuxObserver.java
@@ -118,6 +118,7 @@ public class AmbientLuxObserver {
                         // check again in case we didn't get any
                         // more readings because the sensor settled
                         if (mRingBuffer.size() > 1) {
+                            removeMessages(MSG_TRANSITION);
                             sendEmptyMessageDelayed(MSG_TRANSITION, mThresholdDuration / 2);
                         }
                         break;


### PR DESCRIPTION
As long as the light sensor is providing values, each value change will
enqueue a transition message, which may queue up. Stop doing that and
ensure only one transition message is queued at any given time.

Change-Id: I6e9c5b265066089ff9e0cea7237c2023ed1af30c